### PR TITLE
feat: add lazy loading to hero image

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -92,10 +92,12 @@ const Index = () => {
 
             <div className="relative">
               <div className="rounded-2xl overflow-hidden shadow-2xl">
-                <img 
-                  src={heroImage} 
-                  alt="Cabinet dentaire moderne" 
+                <img
+                  src={heroImage}
+                  alt="Cabinet dentaire moderne"
                   className="w-full h-96 object-cover"
+                  loading="lazy"
+                  decoding="async"
                 />
               </div>
               <div className="absolute -bottom-6 -left-6 bg-white p-4 rounded-xl shadow-lg border">


### PR DESCRIPTION
## Summary
- lazily load hero image on landing page

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype; A `require()` style import is forbidden)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a6cda41168832cb7bbb43914e27d86